### PR TITLE
Helen's changes for ASL

### DIFF
--- a/apriltags2_ros/include/apriltags2_ros/common_functions.h
+++ b/apriltags2_ros/include/apriltags2_ros/common_functions.h
@@ -198,7 +198,7 @@ class TagDetector
     void undistortRectifyImage(const cv::Mat &original_img, cv::Mat &rectified_img);
     void setRadtanUndistortRectifyMap(sensor_msgs::CameraInfo ros_cam_param);
     void setEquidistantUndistortRectifyMap(sensor_msgs::CameraInfo ros_cam_param);
-    tf::StampedTransform T_worldDARPA_;
+    tf::StampedTransform T_target_world_;
     std::string world_frame_;
     std::string target_frame_live_;
     std::string target_frame_post_;

--- a/apriltags2_ros/src/common_functions.cpp
+++ b/apriltags2_ros/src/common_functions.cpp
@@ -395,39 +395,41 @@ AprilTagDetectionArray TagDetector::detectTags(const cv_bridge::CvImagePtr &imag
   }
 
   // If set, publish the transform /tf topic
-  if (publish_tf_)
-  {
-    for (unsigned int i = 0; i < tag_detection_array.detections.size(); i++)
-    {
+  if (publish_tf_) {
+    for (unsigned int i = 0; i < tag_detection_array.detections.size(); i++) {
       geometry_msgs::PoseStamped pose;
       pose.pose = tag_detection_array.detections[i].pose.pose.pose;
       pose.header = tag_detection_array.detections[i].pose.header;
       tf::Stamped<tf::Transform> tag_transform;
       tf::poseStampedMsgToTF(pose, tag_transform);
-      tf_boradcaster_.sendTransform(tf::StampedTransform(tag_transform,
-                                                         tag_transform.stamp_,
-                                                         camera_frame_,
-                                                         detection_names[i]));
+      tf_boradcaster_.sendTransform(
+          tf::StampedTransform(tag_transform, tag_transform.stamp_,
+                               camera_frame_, detection_names[i]));
     }
 
-    //To avoid tf lookup if no tag is detected
-    if (tag_detection_array.detections.size() > 0)
-    {
-      try
-      {
-        tf_listener_.waitForTransform(world_frame_, target_frame_live_, ros::Time(0), ros::Duration(0.1)); //blocking call for 0.1sec
-        tf_listener_.lookupTransform(world_frame_, target_frame_live_, ros::Time(0), T_worldDARPA_);
-      }
-      catch (tf::TransformException &ex)
-      {
+    // To avoid tf lookup if no tag is detected
+
+    if (tag_detection_array.detections.size() > 0) {
+      try {
+        // blocking call for 0.1sec
+        //if (!tf_listener_.waitForTransform(world_frame_, target_frame_live_,
+       //                                    ros::Time::now(),
+       //                                    ros::Duration(0.1))) {
+       //   ROS_ERROR("Couldn't get transform!");
+        //}
+        tf_listener_.lookupTransform(world_frame_, target_frame_live_,
+                                     ros::Time(0.0), T_worldDARPA_);
+      } catch (tf::TransformException &ex) {
         ROS_ERROR("%s", ex.what());
       }
-      tf_boradcaster_.sendTransform(T_worldDARPA_);
-      initTransform_ = true;
-    }
-    else if (initTransform_)
       tfRepublish(ros::Time::now());
+      //tf_boradcaster_.sendTransform(T_worldDARPA_);
+      initTransform_ = true;
+    } else if (initTransform_) {
+      tfRepublish(ros::Time::now());
+    }
   }
+
   return tag_detection_array;
 }
 

--- a/apriltags2_ros/src/continuous_detector.cpp
+++ b/apriltags2_ros/src/continuous_detector.cpp
@@ -53,6 +53,7 @@ ContinuousDetector::ContinuousDetector(ros::NodeHandle &nh_, ros::NodeHandle &pn
   image_mod_value_ = 5; //Default value of 4Hz
   pnh.getParam("image_mod_value", image_mod_value_);
 
+
   //Create Tag detector
   tag_detector_ = std::shared_ptr<TagDetector>(new TagDetector(pnh));
 
@@ -69,6 +70,13 @@ ContinuousDetector::ContinuousDetector(ros::NodeHandle &nh_, ros::NodeHandle &pn
   aprilDetectorOn_ = false;
   tfStartDetectorSrv_ = nh.advertiseService("/aprilTag_startDetector", &ContinuousDetector::tfStartDetectorCallback, this);
   tfStopDetectorSrv_ = nh.advertiseService("/aprilTag_stopDetector", &ContinuousDetector::tfStopDetectorCallback, this);
+
+  bool use_service_calls = true;
+  pnh.getParam("use_service_calls", use_service_calls);
+  ROS_INFO("Use service calls: %d", use_service_calls);
+  if (!use_service_calls) {
+    aprilDetectorOn_ = true;
+  }
 }
 
 /*Quick Un-nodeletize
@@ -128,8 +136,9 @@ void ContinuousDetector::imageCallback(const sensor_msgs::ImageConstPtr &image, 
       }
     }
   }
-  else if (tag_detector_->initTransform_)
+  else if (tag_detector_->initTransform_) {
     tag_detector_->tfRepublish(image->header.stamp);
+  }
 }
 
 //CUSTOMIZATION


### PR DESCRIPTION
All pretty small!
 - *Flip* the DARPA <-> world TF. DARPA is now parent of world.
 - (Also rename the transform name in the code -- let me know if the naming is ok/clear)
 - Change up the TF look-up/publishing a bit to not publish the uninitialized transform.
 - Add a parameter (true by default) to use or not use services to start and stop the detections (because I am lazy while running datasets).